### PR TITLE
Removed unused maxspeed types for Austria

### DIFF
--- a/plugins/TagFix_Maxspeed.py
+++ b/plugins/TagFix_Maxspeed.py
@@ -38,8 +38,6 @@ class TagFix_Maxspeed(Plugin):
     maxspeed_table = {
         'at:rural': ['100'],
         'at:trunk': ['100'],
-        'at:urban40': ['40'],
-        'at:urban30': ['30'],
         'be-bru:rural': ['70'],
         'be-bru:urban': ['30'],
         'be:motorway': ['120'],


### PR DESCRIPTION
at:urban30 and at:urban40 have been superseded by at:city_limit30 and at:city_limit40 (which will be checked in a separate plugin).